### PR TITLE
reader: properly implement io.Reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -8,6 +8,8 @@ type PktlineReader struct {
 	pl *Pktline
 
 	buf []byte
+
+	eof bool
 }
 
 // NewPktlineReader returns a new *PktlineReader, which will read from the
@@ -39,6 +41,10 @@ func NewPktlineReaderFromPktline(pl *Pktline, c int) *PktlineReader {
 func (r *PktlineReader) Read(p []byte) (int, error) {
 	var n int
 
+	if r.eof {
+		return 0, io.EOF
+	}
+
 	if len(r.buf) > 0 {
 		// If there is data in the buffer, shift as much out of it and
 		// into the given "p" as we can.
@@ -62,6 +68,7 @@ func (r *PktlineReader) Read(p []byte) (int, error) {
 			// reached the end of processing for this particular
 			// packet, so let's terminate.
 
+			r.eof = true
 			return n, io.EOF
 		}
 
@@ -78,4 +85,10 @@ func (r *PktlineReader) Read(p []byte) (int, error) {
 	}
 
 	return n, nil
+}
+
+// Reset causes the reader to reset the end-of-file indicator and continue
+// reading packets from the underlying reader.
+func (r *PktlineReader) Reset() {
+	r.eof = false
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -141,3 +141,34 @@ func TestPktlineReaderReadsManyPacketsInMultipleCallsWithEvenBuffering(t *testin
 	assert.Equal(t, 0, n3)
 	assert.Equal(t, io.EOF, e3)
 }
+
+func TestPktlineReaderReadEOFAfterEOF(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(t, &buf, []byte("asdf"))
+	writePacket(t, &buf, []byte("abcd"))
+
+	pr := NewPktlineReader(&buf, 10)
+
+	var p1 [5]byte
+
+	n, err := pr.Read(p1[:])
+	assert.Equal(t, err, io.EOF)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, []byte("asdf"), p1[0:n])
+
+	n, err = pr.Read(p1[:])
+	assert.Equal(t, err, io.EOF)
+	assert.Equal(t, 0, n)
+
+	pr.Reset()
+
+	n, err = pr.Read(p1[:])
+	assert.Equal(t, err, io.EOF)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, []byte("abcd"), p1[0:n])
+
+	n, err = pr.Read(p1[:])
+	assert.Equal(t, err, io.EOF)
+	assert.Equal(t, 0, n)
+}


### PR DESCRIPTION
The io.Reader interface specifies that once we reach an EOF indicator, the next read from the stream should return 0, io.EOF.  However, our reader didn't work that way, causing us to attempt to read the next packet from the underlying reader.  In some cases, such a packet won't exist until we've responded to the one we already got, causing us to hang.

This was fixed in git-lfs/git-lfs#3902, but never ported over to here. Let's port that change over here, and add a Reset method to allow users to continue with the next packet if there's more data to read from the underlying stream.
