### PR TITLE
Update default branch name in security documentation and drop copyright end date

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2020 GitHub, Inc. and Git LFS contributors
+Copyright (c) 2014- GitHub, Inc. and Git LFS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 Please see
-[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/master/SECURITY.md)
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/main/SECURITY.md)
 in the main Git LFS repository for information on how to report security
 vulnerabilities in this package.


### PR DESCRIPTION
We update our link to the Git LFS project's main security documentation in the `git-lfs/git-lfs` repository to use that repository's current default branch name of `main`.

As well, since most of our other Git LFS projects contain license files without copyright end dates, which saves us needing to update them, we do the same here also.